### PR TITLE
Fall back to page URL if no script tags present

### DIFF
--- a/.sencha/package/Boot.js
+++ b/.sencha/package/Boot.js
@@ -590,8 +590,12 @@ Ext.Boot = Ext.Boot || (function (emptyFn) {
                 }
 
                 if (!baseUrl) {
-                    script = scriptEls[scriptEls.length - 1];
-                    baseUrl = script.src;
+                    if (len) {
+                        script = scriptEls[len - 1];
+                        baseUrl = script.src;
+                    } else {
+                        baseUrl = window.location.href;
+                    }
                 }
 
                 Boot.baseUrl = baseUrl.substring(0, baseUrl.lastIndexOf('/') + 1);


### PR DESCRIPTION
The previous code assumed that at least one script tag exists on a page and crashes if this is not true. Further, it does not make use of the `len` variable that is available.

When used to build browser extensions, it is possible for the page an application is loaded onto to contain no script tags